### PR TITLE
Fix toggle

### DIFF
--- a/ParallelRoadTool/ParallelRoadTool.cs
+++ b/ParallelRoadTool/ParallelRoadTool.cs
@@ -32,8 +32,7 @@ namespace ParallelRoadTool
 
         public bool IsToolActive
         {
-            // TODO: checkbox outside main panel is not working, so we need to show the panel even if the tool has been disabled
-            get => /*_isToolActive &&*/ NetTool.enabled;
+            get => _isToolActive && NetTool.enabled;
 
             private set
             {

--- a/ParallelRoadTool/UI/Base/UIUtil.cs
+++ b/ParallelRoadTool/UI/Base/UIUtil.cs
@@ -176,7 +176,7 @@ namespace ParallelRoadTool.UI.Base
             dropDown.selectedIndex = 0;
             dropDown.textFieldPadding = new RectOffset(14, 0, 14, 0);
             dropDown.itemPadding = new RectOffset(14, 0, 8, 0);
-            dropDown.listPosition = UIDropDown.PopupListPosition.Automatic;
+            dropDown.listPosition = UIDropDown.PopupListPosition.Below;
             dropDown.listOffset = new Vector2(0, 0);
 
             var button = dropDown.AddUIComponent<UIButton>();

--- a/ParallelRoadTool/UI/UIMainWindow.cs
+++ b/ParallelRoadTool/UI/UIMainWindow.cs
@@ -70,19 +70,27 @@ namespace ParallelRoadTool.UI
         public override void Start()
         {
             name = "PRT_MainWindow";
-            atlas = ResourceLoader.GetAtlas("Ingame");
-            backgroundSprite = "SubcategoriesPanel";
             isVisible = false;
-            size = new Vector2(450, 280);
-            padding = new RectOffset(8, 8, 8, 8);
-            autoLayoutPadding = new RectOffset(0, 0, 0, 4);
+            size = new Vector2(500, 240);
+            autoFitChildrenVertically = true;
+            absolutePosition = new Vector3(SavedWindowX.value, SavedWindowY.value);
 
-            var label = AddUIComponent<UILabel>();
+            var bg = AddUIComponent<UIPanel>();
+            bg.atlas = ResourceLoader.GetAtlas("Ingame");
+            bg.backgroundSprite = "SubcategoriesPanel";
+            bg.size = size;
+            bg.padding = new RectOffset(8, 8, 8, 8);
+            bg.autoLayoutPadding = new RectOffset(0, 0, 0, 4);
+            bg.autoLayout = true;
+            bg.autoLayoutDirection = LayoutDirection.Vertical;
+            bg.autoFitChildrenVertically = true;
+
+            var label = bg.AddUIComponent<UILabel>();
             label.name = "PRT_TitleLabel";
             label.textScale = 0.9f;
             label.text = "Parallel Road Tool";
             label.autoSize = false;
-            label.width = 450;
+            label.width = 500;
             label.SendToBack();
 
             var dragHandle = label.AddUIComponent<UIDragHandle>();
@@ -90,21 +98,15 @@ namespace ParallelRoadTool.UI
             dragHandle.relativePosition = Vector3.zero;
             dragHandle.size = label.size;
  
-            autoFitChildrenVertically = true;
-            autoLayout = true;
-            autoLayoutDirection = LayoutDirection.Vertical;
-
-            absolutePosition = new Vector3(SavedWindowX.value, SavedWindowY.value);
-
-            _mainPanel = AddUIComponent(typeof(UIOptionsPanel)) as UIOptionsPanel;
-            _netList = AddUIComponent(typeof(UINetList)) as UINetList;
+            _mainPanel = bg.AddUIComponent(typeof(UIOptionsPanel)) as UIOptionsPanel;
+            _netList = bg.AddUIComponent(typeof(UINetList)) as UINetList;
             if (_netList != null)
             {
                 _netList.List = ParallelRoadTool.SelectedRoadTypes;
                 _netList.OnChangedCallback = NetListOnChangedCallback;
             }
 
-            var space = AddUIComponent<UIPanel>();
+            var space = bg.AddUIComponent<UIPanel>();
             space.size = new Vector2(1, 1);
 
             // Add main tool button to road options panel
@@ -132,8 +134,9 @@ namespace ParallelRoadTool.UI
             if (ParallelRoadTool.NetTool != null)
                 _toolToggleButton.isVisible = ParallelRoadTool.NetTool.enabled;
 
-
             base.Update();
+
+
         }
 
         public override void OnDestroy()
@@ -158,6 +161,7 @@ namespace ParallelRoadTool.UI
             SavedWindowX.value = (int) absolutePosition.x;
             SavedWindowY.value = (int) absolutePosition.y;
         }
+
 
         public void OnGUI()
         {

--- a/ParallelRoadTool/UI/UIMainWindow.cs
+++ b/ParallelRoadTool/UI/UIMainWindow.cs
@@ -153,7 +153,7 @@ namespace ParallelRoadTool.UI
                 (int) Mathf.Clamp(absolutePosition.x, 0, resolution.x - width),
                 (int) Mathf.Clamp(absolutePosition.y, 0, resolution.y - height));
 
-            DebugUtils.Log($"UIMainWindow OnPositionChanged | {resolution} | {absolutePosition}");
+            //DebugUtils.Log($"UIMainWindow OnPositionChanged | {resolution} | {absolutePosition}");
 
             SavedWindowX.value = (int) absolutePosition.x;
             SavedWindowY.value = (int) absolutePosition.y;

--- a/ParallelRoadTool/UI/UIMainWindow.cs
+++ b/ParallelRoadTool/UI/UIMainWindow.cs
@@ -110,19 +110,13 @@ namespace ParallelRoadTool.UI
             // Add main tool button to road options panel
             if (_toolToggleButton != null) return;
 
-            var roadsOptionPanel = UIUtil.FindComponent<UIComponent>("RoadsOptionPanel", null, UIUtil.FindOptions.NameContains);
-            if (roadsOptionPanel == null || !roadsOptionPanel.gameObject.activeInHierarchy) return;
+            var tsBar = UIUtil.FindComponent<UIComponent>("TSBar", null, UIUtil.FindOptions.NameContains);
+            if (tsBar == null || !tsBar.gameObject.activeInHierarchy) return;
             var button = UIUtil.FindComponent<UICheckBox>("PRT_Parallel");
             if (button != null)
                 Destroy(button);
-            _toolToggleButton = UIUtil.CreateCheckBox(roadsOptionPanel, "Parallel", "Parallel Road Tool", false);
-            _toolToggleButton.relativePosition = new Vector3(166, 38);
-            _toolToggleButton.BringToFront();
-
-#if !DEBUG
-            // TODO: button is not working, hide it when not in debug
-            _toolToggleButton.isVisible = false;
-#endif
+            _toolToggleButton = UIUtil.CreateCheckBox(tsBar, "Parallel", "Parallel Road Tool", false);
+            _toolToggleButton.relativePosition = new Vector3(424, -6);
 
             SubscribeToUIEvents();
 
@@ -134,7 +128,11 @@ namespace ParallelRoadTool.UI
         {
             if (ParallelRoadTool.Instance != null)
                 isVisible = ParallelRoadTool.Instance.IsToolActive;
-       
+
+            if (ParallelRoadTool.NetTool != null)
+                _toolToggleButton.isVisible = ParallelRoadTool.NetTool.enabled;
+
+
             base.Update();
         }
 

--- a/ParallelRoadTool/UI/UINetList.cs
+++ b/ParallelRoadTool/UI/UINetList.cs
@@ -21,7 +21,7 @@ namespace ParallelRoadTool.UI
         {
             name = "PRT_NetList";
             padding = new RectOffset(4, 4, 4, 0);
-            size = new Vector2(450 - 8*2, 200);
+            size = new Vector2(500 - 8*2, 200);
             autoLayoutPadding = new RectOffset(0, 0, 0, 4);
             autoFitChildrenVertically = true;
             autoLayout = true;

--- a/ParallelRoadTool/UI/UINetTypeItem.cs
+++ b/ParallelRoadTool/UI/UINetTypeItem.cs
@@ -9,8 +9,8 @@ namespace ParallelRoadTool.UI
 {
     public class UINetTypeItem : UIPanel
     {
-        private const int TextFieldWidth = 50;
-        private const int LabelWidth = 230;
+        private const int TextFieldWidth = 65;
+        private const int LabelWidth = 250;
         private const float ColumnPadding = 8f;
         private const int ReverseButtonWidth = 36;
         public float HorizontalOffset;
@@ -40,12 +40,15 @@ namespace ParallelRoadTool.UI
             atlas = ResourceLoader.GetAtlas("Ingame");
             backgroundSprite = "SubcategoriesPanel";
             color = new Color32(255, 255, 255, 255);
-            size = new Vector2(450 - 8 * 2 - 4 * 2, 40);
+            size = new Vector2(500 - 8 * 2 - 4 * 2, 40);
 
+            var panel = AddUIComponent<UIPanel>();
+            panel.size = new Vector2(LabelWidth, 40);
+            panel.relativePosition = Vector2.zero;
 
-            DropDown = UIUtil.CreateDropDown(this);
+            DropDown = UIUtil.CreateDropDown(panel);
             DropDown.width = LabelWidth;
-            DropDown.relativePosition = new Vector3(0, 0);
+            DropDown.relativePosition = Vector2.zero;
             DropDown.eventSelectedIndexChanged += DropDown_eventSelectedIndexChanged;
 
             ReverseCheckbox = UIUtil.CreateCheckBox(this, "Reverse", "Toggle reverse road", false);
@@ -63,7 +66,6 @@ namespace ParallelRoadTool.UI
                 new Vector3(LabelWidth + 3 * ColumnPadding + ReverseButtonWidth + TextFieldWidth, 10);
             VerticalOffsetField.width = TextFieldWidth;
             VerticalOffsetField.eventTextSubmitted += VerticalOffsetField_eventTextSubmitted;
-
 
             Label = AddUIComponent<UILabel>();
             Label.textScale = .8f;

--- a/ParallelRoadTool/UI/UIOptionsPanel.cs
+++ b/ParallelRoadTool/UI/UIOptionsPanel.cs
@@ -7,7 +7,6 @@ namespace ParallelRoadTool.UI
 {
     public class UIOptionsPanel : UIPanel
     {
-        private UICheckBox _toolToggleButton;
 
         #region Events
 
@@ -29,11 +28,6 @@ namespace ParallelRoadTool.UI
             autoLayout = true;
             autoSize = false;
             
-            _toolToggleButton = UIUtil.CreateCheckBox(this, "Parallel", "Toggle parallel road tool", false);
-            _toolToggleButton.eventCheckChanged += (component, value) =>
-            {
-                OnToolToggled?.Invoke(_toolToggleButton, _toolToggleButton.isChecked);
-            };
 
             DebugUtils.Log($"UIOptionsPanel created {size} | {position}");
         }

--- a/ParallelRoadTool/UI/UIOptionsPanel.cs
+++ b/ParallelRoadTool/UI/UIOptionsPanel.cs
@@ -20,7 +20,7 @@ namespace ParallelRoadTool.UI
             atlas = ResourceLoader.GetAtlas("Ingame");
             backgroundSprite = "GenericPanel";
             color = new Color32(206, 206, 206, 255);
-            size = new Vector2(450 - 8 * 2, 36 + 2 * 8);
+            size = new Vector2(500 - 8 * 2, 36 + 2 * 8);
 
             padding = new RectOffset(8, 8, 8, 8);
             autoLayoutPadding = new RectOffset(0, 4, 0, 0);


### PR DESCRIPTION
Children of RoadsOptionPanel seem to not get the click events. Adding it to TSBar instead works.

Also, can you check if commenting out the log in the window onChanged handler helps with performance? On my machine, both with and without works flawlessly...