### PR TITLE
Japanese translation and more

### DIFF
--- a/ParallelRoadTool/Localization/en.xml
+++ b/ParallelRoadTool/Localization/en.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <NameList
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -12,6 +12,7 @@
     <LocalizedString identifier="PRT_TOOLTIPS" key="AddNetworkButton">Add network</LocalizedString>
     
     <LocalizedString identifier="PRT_TEXTS" key="SameAsSelectedLabel">Same as selected</LocalizedString>
+    <LocalizedString identifier="PRT_TEXTS" key="SameAsSelectedRoad">Same as selected road</LocalizedString>
     <LocalizedString identifier="PRT_TEXTS" key="DecreaseHorizontalOffsetOption">Decrease horizontal offset of parallel networks</LocalizedString>
     <LocalizedString identifier="PRT_TEXTS" key="IncreaseHorizontalOffsetOption">Increase horizontal offset of parallel networks</LocalizedString>
     <LocalizedString identifier="PRT_TEXTS" key="DecreaseVerticalOffsetOption">Decrease vertical offset of parallel networks</LocalizedString>

--- a/ParallelRoadTool/Localization/ja.xml
+++ b/ParallelRoadTool/Localization/ja.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<NameList
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    name="PRT_ja">
+  <strings>
+    <LocalizedString identifier="PRT_TOOLTIPS" key="SnappingToggleButton">既存のノードをスナップするかどうか切り替え</LocalizedString>
+    <LocalizedString identifier="PRT_TOOLTIPS" key="ToolToggleButton">Parallel Road Tool のオン／オフ</LocalizedString>
+    <LocalizedString identifier="PRT_TOOLTIPS" key="TutorialToggleButton">チュートリアル画面の表示／非表示</LocalizedString>
+    <LocalizedString identifier="PRT_TOOLTIPS" key="ReverseToggleButton">この道路の向きを反転</LocalizedString>
+    <LocalizedString identifier="PRT_TOOLTIPS" key="RemoveNetworkButton">道路を削除</LocalizedString>
+    <LocalizedString identifier="PRT_TOOLTIPS" key="AddNetworkButton">道路を追加</LocalizedString>
+    
+    <LocalizedString identifier="PRT_TEXTS" key="SameAsSelectedLabel">選択中の道路と同じ道路</LocalizedString>
+    <LocalizedString identifier="PRT_TEXTS" key="SameAsSelectedRoad">選択中の道路と同じ道路</LocalizedString>
+    <LocalizedString identifier="PRT_TEXTS" key="DecreaseHorizontalOffsetOption">並行する道路の水平方向の隙間を減らす</LocalizedString>
+    <LocalizedString identifier="PRT_TEXTS" key="IncreaseHorizontalOffsetOption">並行する道路の水平方向の隙間を増やす</LocalizedString>
+    <LocalizedString identifier="PRT_TEXTS" key="DecreaseVerticalOffsetOption">並行する道路の垂直方向の隙間を減らす</LocalizedString>
+    <LocalizedString identifier="PRT_TEXTS" key="IncreaseVerticalOffsetOption">並行する道路の垂直方向の隙間を減らす</LocalizedString>
+
+    <LocalizedString identifier="TUTORIAL_ADVISER_TITLE" key="ParallelRoadTool">Parallel Road Tool</LocalizedString>
+    <LocalizedString identifier="TUTORIAL_ADVISER" key="ParallelRoadTool">(もし上に画像が表示されていなければ、いったんチュートリアルを 閉じて、再度開いて下さい)
+      1) リストへ現在選択されている道路を追加します
+      2) 選択した道路を別のものに変更することができます
+      3) 道路の向きを反転させます
+      4) 道路の水平方向の隙間
+      5) 道路の垂直方向の隙間
+      6) リストから道路を削除
+      7) 既存のノードすべてをスナップするかどうか切り替える。
+         無効: MOD を有効にしてから引いたセグメントのみスナップ。
+         有効: 接続可能な最も近いセグメントのスナップを試みる。
+       水平方向、垂直方向ともに負の値を指定することができます。
+       水平方向の隙間に負の値を指定したら、反対側に道路を置きます。
+       垂直方向の隙間に負の値を指定したら、地面の下に道路を置きます。
+    </LocalizedString>
+  </strings>
+</NameList>

--- a/ParallelRoadTool/Localization/ru.xml
+++ b/ParallelRoadTool/Localization/ru.xml
@@ -12,6 +12,7 @@
     <LocalizedString identifier="PRT_TOOLTIPS" key="AddNetworkButton">Добавить</LocalizedString>
     
     <LocalizedString identifier="PRT_TEXTS" key="SameAsSelectedLabel">То же, что выбрано</LocalizedString>
+    <LocalizedString identifier="PRT_TEXTS" key="SameAsSelectedRoad">То же, что выбрано</LocalizedString>
     <LocalizedString identifier="PRT_TEXTS" key="DecreaseHorizontalOffsetOption">Уменьшение расстояния по горизонтали между дорогами/конструкциями</LocalizedString>
     <LocalizedString identifier="PRT_TEXTS" key="IncreaseHorizontalOffsetOption">Увеличение расстояния по горизонтали между дорогами/конструкциями</LocalizedString>
     <LocalizedString identifier="PRT_TEXTS" key="DecreaseVerticalOffsetOption">Уменьшение расстояния по вертикали между дорогами/конструкциями</LocalizedString>

--- a/ParallelRoadTool/ModInfo.cs
+++ b/ParallelRoadTool/ModInfo.cs
@@ -1,7 +1,15 @@
 ﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Serialization;
 using ColossalFramework;
+using ColossalFramework.Globalization;
 using ColossalFramework.UI;
 using ICities;
+using ParallelRoadTool.Extensions.LocaleModels;
+using UnityEngine;
 
 namespace ParallelRoadTool
 {
@@ -39,6 +47,36 @@ namespace ParallelRoadTool
         {
             try
             {
+                XmlSerializer serializer = new XmlSerializer(typeof(NameList));
+
+                var assembly = Assembly.GetExecutingAssembly();
+                // BUG: on Mac and Linux LocalManager.cultureInfo always returns 'en' regardless of game language
+                //var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.cultureInfo.TwoLetterISOLanguageName}.xml";
+                var lang = LocaleManager.instance.language;
+                var resourceName = $"ParallelRoadTool.Localization.{lang}.xml";
+
+                if (!assembly.GetManifestResourceNames().Contains(resourceName))
+                {
+                    // Fallback to english
+                    resourceName = "ParallelRoadTool.Localization.en.xml";
+                }
+
+                DebugUtils.Log($"Trying to read {resourceName} localization file...");
+                using (Stream stream = assembly.GetManifestResourceStream(resourceName))
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    using (XmlReader xmlStream = XmlReader.Create(reader))
+                    {
+                        if (serializer.CanDeserialize(xmlStream))
+                        {
+                            NameList nameList = (NameList)serializer.Deserialize(xmlStream);
+                            nameList.Apply();
+                        }
+                    }
+                }
+
+                DebugUtils.Log($"Namelists {resourceName} applied.");
+
                 var group = helper.AddGroup(Name) as UIHelper;
                 var panel = group.self as UIPanel;
 

--- a/ParallelRoadTool/ParallelRoadTool.cs
+++ b/ParallelRoadTool/ParallelRoadTool.cs
@@ -271,7 +271,10 @@ namespace ParallelRoadTool
             XmlSerializer serializer = new XmlSerializer(typeof(NameList));
 
             var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.cultureInfo.TwoLetterISOLanguageName}.xml";
+            // BUG: on Mac and Linux LocalManager.cultureInfo always returns 'en' regardless of game language
+            //var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.cultureInfo.TwoLetterISOLanguageName}.xml";
+            var lang = LocaleManager.instance.language;
+            var resourceName = $"ParallelRoadTool.Localization.{lang}.xml";
 
             if (!assembly.GetManifestResourceNames().Contains(resourceName))
             {

--- a/ParallelRoadTool/UI/Base/UIUtil.cs
+++ b/ParallelRoadTool/UI/Base/UIUtil.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using ColossalFramework.Globalization;
 using ColossalFramework.UI;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -202,7 +203,9 @@ namespace ParallelRoadTool.UI.Base
 
             if (prefab == null)
             {
-                itemName = "Same as selected road";
+                // BUG: This needs to be translatable
+                //itemName = "Same as selected road";
+                itemName = Locale.Get("PRT_TEXT", "SameAsSelectedRoad");
             }
             else
             {


### PR DESCRIPTION
Add Japanese translations and bug fixes:
1) fixed a bug which caused no translated strings in Option screen on Main Menu.
2) fixed a bug which caused always showing en strings on Mac and Linux.
3) fixed 1 untranslatable string.