### PR TITLE
fix 2 bugs

### DIFF
--- a/ParallelRoadTool/ModInfo.cs
+++ b/ParallelRoadTool/ModInfo.cs
@@ -51,8 +51,7 @@ namespace ParallelRoadTool
                 XmlSerializer serializer = new XmlSerializer(typeof(NameList));
 
                 var assembly = Assembly.GetExecutingAssembly();
-                var lang = LocaleManager.instance.language;
-                var resourceName = $"ParallelRoadTool.Localization.{lang}.xml";
+                var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.instance.language}.xml";
 
                 if (!assembly.GetManifestResourceNames().Contains(resourceName))
                 {

--- a/ParallelRoadTool/ModInfo.cs
+++ b/ParallelRoadTool/ModInfo.cs
@@ -8,6 +8,7 @@ using ColossalFramework;
 using ColossalFramework.Globalization;
 using ColossalFramework.UI;
 using ICities;
+using ParallelRoadTool;
 using ParallelRoadTool.Extensions.LocaleModels;
 using UnityEngine;
 
@@ -48,36 +49,8 @@ namespace ParallelRoadTool
             try
             {
                 // BUG: No translated strings in Option screen on Main Menu.
-                XmlSerializer serializer = new XmlSerializer(typeof(NameList));
-
-                var assembly = Assembly.GetExecutingAssembly();
-                var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.instance.language}.xml";
-
-                if (!assembly.GetManifestResourceNames().Contains(resourceName))
-                {
-                    // Fallback to english
-                    resourceName = "ParallelRoadTool.Localization.en.xml";
-                }
-
-                DebugUtils.Log($"Trying to read {resourceName} localization file...");
-                using (Stream stream = assembly.GetManifestResourceStream(resourceName))
-                using (StreamReader reader = new StreamReader(stream))
-                {
-                    using (XmlReader xmlStream = XmlReader.Create(reader))
-                    {
-                        if (serializer.CanDeserialize(xmlStream))
-                        {
-                            NameList nameList = (NameList)serializer.Deserialize(xmlStream);
-                            nameList.Apply();
-                        }
-                    }
-                }
-
-                DebugUtils.Log($"Namelists {resourceName} applied.");
-
-                var group = helper.AddGroup(Name) as UIHelper;
-                var panel = group.self as UIPanel;
-
+                ParallelRoadTool.OnLocaleChanged();
+                
                 panel.gameObject.AddComponent<OptionsKeymapping>();
 
                 group.AddSpace(10);

--- a/ParallelRoadTool/ParallelRoadTool.cs
+++ b/ParallelRoadTool/ParallelRoadTool.cs
@@ -273,8 +273,7 @@ namespace ParallelRoadTool
             var assembly = Assembly.GetExecutingAssembly();
             // BUG: on Mac and Linux LocalManager.cultureInfo always returns 'en' regardless of game language
             //var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.cultureInfo.TwoLetterISOLanguageName}.xml";
-            var lang = LocaleManager.instance.language;
-            var resourceName = $"ParallelRoadTool.Localization.{lang}.xml";
+            var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.instance.language}.xml";
 
             if (!assembly.GetManifestResourceNames().Contains(resourceName))
             {

--- a/ParallelRoadTool/ParallelRoadTool.cs
+++ b/ParallelRoadTool/ParallelRoadTool.cs
@@ -271,7 +271,10 @@ namespace ParallelRoadTool
             XmlSerializer serializer = new XmlSerializer(typeof(NameList));
 
             var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.cultureInfo.TwoLetterISOLanguageName}.xml";
+            // BUG: on Mac and Linux LocalManager.cultureInfo always returns 'en' regardless of game language
+            //var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.cultureInfo.TwoLetterISOLanguageName}.xml";
+            var lang = LocaleManager.instance.language;
+            var resourceName = $"ParallelRoadTool.Localization.{lang}.xml";
 
             if (!assembly.GetManifestResourceNames().Contains(resourceName))
             {

--- a/ParallelRoadTool/ParallelRoadTool.cs
+++ b/ParallelRoadTool/ParallelRoadTool.cs
@@ -264,7 +264,7 @@ namespace ParallelRoadTool
             LocaleManager.ForceReload();
         }
 
-        private void OnLocaleChanged()
+        public void OnLocaleChanged()
         {
             DebugUtils.Log("Locale changed callback started.");
 


### PR DESCRIPTION
fixed 2 bugs:
1) No translated strings in Option screen on Main Menu.
2) On Mac and Linux LocaleManager.cultureInfo always returns 'en' regardless of game language.