### PR TITLE
Fixed 2 bugs

### DIFF
--- a/ParallelRoadTool/ModInfo.cs
+++ b/ParallelRoadTool/ModInfo.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using ColossalFramework;
 using ColossalFramework.UI;
 using ICities;
+using ParallelRoadTool;
 
 namespace ParallelRoadTool
 {
@@ -39,9 +40,13 @@ namespace ParallelRoadTool
         {
             try
             {
+                // BUG: No translated strings in Option screen on Main Menu.
+                var ld = new ParallelRoadToolLoader();
+                ld.OnLocaleChanged();
+
                 var group = helper.AddGroup(Name) as UIHelper;
                 var panel = group.self as UIPanel;
-
+                
                 panel.gameObject.AddComponent<OptionsKeymapping>();
 
                 group.AddSpace(10);

--- a/ParallelRoadTool/ParallelRoadTool.cs
+++ b/ParallelRoadTool/ParallelRoadTool.cs
@@ -264,14 +264,16 @@ namespace ParallelRoadTool
             LocaleManager.ForceReload();
         }
 
-        private void OnLocaleChanged()
+        public void OnLocaleChanged()
         {
             DebugUtils.Log("Locale changed callback started.");
 
             XmlSerializer serializer = new XmlSerializer(typeof(NameList));
 
             var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.cultureInfo.TwoLetterISOLanguageName}.xml";
+            // BUG: on Mac and Linux LocalManager.cultureInfo always returns 'en' regardless of game language
+            //var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.cultureInfo.TwoLetterISOLanguageName}.xml";
+            var resourceName = $"ParallelRoadTool.Localization.{LocaleManager.instance.language}.xml";
 
             if (!assembly.GetManifestResourceNames().Contains(resourceName))
             {


### PR DESCRIPTION
Fixed 2 bugs:
1) On Mac and Linux LocaleManager.cultureInfo() always returns 'en' regardless of game language.
2) No translated strings in Option screen on Main Menu.