### PR TITLE
Fix Issue 106 - Plaza and Promenades Compatibility

### DIFF
--- a/ParallelRoadTool/Detours/NetManagerDetour.cs
+++ b/ParallelRoadTool/Detours/NetManagerDetour.cs
@@ -162,17 +162,17 @@ namespace ParallelRoadTool.Detours
 
             if (Singleton<ParallelRoadTool>.instance.IsSnappingEnabled &&
                 (PathManager.FindPathPosition(newNodePosition, info.m_class.m_service, info.m_class.m_service,
-                                              NetInfo.LaneType.All, VehicleInfo.VehicleType.All, VehicleInfo.VehicleType.All, true, false,
+                                              NetInfo.LaneType.All, VehicleInfo.VehicleType.All, VehicleInfo.VehicleCategory.All, VehicleInfo.VehicleType.All, true, false,
                                               maxDistance, out var posA, out var posB, out _, out _) ||
                  PathManager.FindPathPosition(
                                               new Vector3(newNodePosition.x, newNodePosition.y - verticalOffset, newNodePosition.z),
                                               info.m_class.m_service, info.m_class.m_service, NetInfo.LaneType.All, VehicleInfo.VehicleType.All,
-                                              VehicleInfo.VehicleType.All, true, false, maxDistance, out posA, out posB, out _,
+                                              VehicleInfo.VehicleCategory.All, VehicleInfo.VehicleType.All, true, false, maxDistance, out posA, out posB, out _,
                                               out _) ||
                  PathManager.FindPathPosition(
                                               new Vector3(newNodePosition.x, newNodePosition.y + verticalOffset, newNodePosition.z),
                                               info.m_class.m_service, info.m_class.m_service, NetInfo.LaneType.All, VehicleInfo.VehicleType.All,
-                                              VehicleInfo.VehicleType.All, true, false, maxDistance, out posA, out posB, out _,
+                                              VehicleInfo.VehicleCategory.All, VehicleInfo.VehicleType.All, true, false, maxDistance, out posA, out posB, out _,
                                               out _)
                 )
                )


### PR DESCRIPTION
Updated calls to FindPathPosition - looks like previously used overload is no longer available